### PR TITLE
Wait for postgres to start instead of adding a random sleep

### DIFF
--- a/9.4/start.sh
+++ b/9.4/start.sh
@@ -14,9 +14,8 @@ fi
 trap "service postgresql stop; exit" SIGHUP SIGINT SIGTERM
 
 # Start postgres
-echo "Restarting postgres..."
-service postgresql restart
-sleep 5
+echo "Start Postgres and wait for start to finish ..."
+su postgres -c "${PGBIN}/pg_ctl start -w"
 
 # UTF8
 echo "Setting up encoding..."


### PR DESCRIPTION
This has been a general cause of annoyance for a while. Fixing it finally. Now we just wait until the db is started, regardless of what other containers are starting on that system. The problem seems to occur when we start a bunch of containers together at random times. 